### PR TITLE
DF-Hotkeys: Make Ctrl+W warning more general.

### DIFF
--- a/lib-df-hotkeys/lang/en.json
+++ b/lib-df-hotkeys/lang/en.json
@@ -2,7 +2,7 @@
 	"DF_HOTKEYS.ModName": "Library: DF Hotkeys",
 
 	"DF_HOTKEYS.Config_Title": "Hotkeys Settings",
-	"DF_HOTKEYS.Config_Warning": "Beware <code>Ctrl+W</code> on Chromium browsers (Chrome, Edge, Brave). This combo will close the browser.",
+	"DF_HOTKEYS.Config_Warning": "Beware <code>Ctrl+W</code>. On many browsers, this key combo will close the tab, window, or application.",
 	"DF_HOTKEYS.Config_Table_Name": "Hotkey Name",
 	"DF_HOTKEYS.Config_Table_Key": "Key Binding",
 	"DF_HOTKEYS.Config_Table_Mods": "Modifiers",


### PR DESCRIPTION
Make the Ctrl+W warning more general.

As far as I know, this key combination closes the current tab on all modern browsers (Chromium, Firefox, Edge, etc.). On older browsers, I believe it closes the entire window (though I'm not certain).