### PR TITLE
find button by name, Resolved conflict

### DIFF
--- a/df-chat-enhance/src/privacy/df-chat-privacy.ts
+++ b/df-chat-enhance/src/privacy/df-chat-privacy.ts
@@ -50,8 +50,8 @@ async function handleChatLogRendering(chat: ChatLog, html: JQuery<HTMLElement>, 
 		buttonHtml.find('button.active').removeClass('active');
 		$(this).addClass('active');
 	});
-	html.find('select.roll-type-select').after(buttonHtml);
-	html.find('select.roll-type-select').remove();
+	html.find('[name=rollMode]').after(buttonHtml);
+	html.find('[name=rollMode]').remove();
 
 	if (!game.settings.get(CONFIG.MOD_NAME, 'replace-buttons'))
 		return;


### PR DESCRIPTION
I have a modules used class roll-type-select .
So when this modules  fuction, it will like below.

![image](https://user-images.githubusercontent.com/23254376/131208377-29a09041-f091-47f9-aafc-e8154e2965a8.png)

so i change find(select.roll-type-select) to  html.find("[name=rollMode]")

and fix the problem

![image](https://user-images.githubusercontent.com/23254376/131208368-29ce8c83-4eda-4144-9738-6477243d6b57.png)
