### PR TITLE
Fixed module.js deprecation

### DIFF
--- a/df-active-lights/module.json
+++ b/df-active-lights/module.json
@@ -4,14 +4,18 @@
 	"version": "1.2.1",
 	"description": "Lights can now have complex animations attached to their various properties such as the direction or colour.",
 	"author": "flamewave000#0001",
-	"minimumCoreVersion": "9",
-	"compatibleCoreVersion": "9",
+	"compatibility": {
+		"minimum": "9",
+		"verified": "9"
+	},
 	"esmodules": "{{sources}}",
 	"styles": "{{css}}",
 	"languages": [
 		{ "lang": "en", "name": "English", "path": "lang/en.json" }
 	],
-	"dependencies": [ { "name": "lib-wrapper" } ],
+	"relationships": {
+		"requires": [ { "id": "lib-wrapper" } ]
+	},
 	"url":		"https://github.com/flamewave000/dragonflagon-fvtt/tree/master/df-active-lights",
 	"license":	"https://raw.githubusercontent.com/flamewave000/dragonflagon-fvtt/master/LICENSE",
 	"manifest":	"https://dragonflagon.cafe/mods/man/df-active-lights",

--- a/df-chat-enhance/module.json
+++ b/df-chat-enhance/module.json
@@ -4,12 +4,16 @@
 	"description": "Various enhancements to the chat features.",
 	"version": "4.0.0",
 	"author": "flamewave000#0001",
-	"minimumCoreVersion": "9.269",
-	"compatibleCoreVersion": "9",
-	"dependencies": [
-		{ "name": "_chatcommands" },
-		{ "name": "lib-wrapper" }
-	],
+	"compatibility": {
+		"minimum": "9.269",
+		"verified": "9"
+	},
+	"relationships": {
+		"requires": [
+			{ "id": "_chatcommands"},
+			{ "id": "lib-wrapper"}
+		]
+	},
 	"scripts": [ "libs/marked.min.js" ],
 	"esmodules": "{{sources}}",
 	"styles": "{{css}}",

--- a/df-curvy-walls/module.json
+++ b/df-curvy-walls/module.json
@@ -4,12 +4,16 @@
 	"title": "DF Curvy Walls",
 	"description": "Creates wall segments along a Bezier Cubic or Quadratic curve, an ellipse, or a rectangle",
 	"author": "flamewave000#0001",
-	"minimumCoreVersion": "9",
-	"compatibleCoreVersion": "9",
-	"dependencies": [
-		{ "name": "lib-wrapper" },
-		{ "name": "lib-df-buttons" }
-	],
+	"compatibility": {
+		"minimum": "9",
+		"verified": "9"
+	},
+	"relationships": {
+		"requires": [
+			{ "id": "lib-wrapper" },
+			{ "id": "lib-df-buttons" }
+		]
+	},
 	"esmodules": "{{sources}}",
 	"styles": "{{css}}",
 	"languages": [

--- a/df-flag-edit/module.json
+++ b/df-flag-edit/module.json
@@ -4,8 +4,10 @@
 	"version": "1.1.2",
 	"description": "Foundry Document Flags Editor",
 	"author": "flamewave000#0001",
-	"minimumCoreVersion": "0.8.9",
-	"compatibleCoreVersion": "9",
+	"compatibility": {
+		"minimum": "0.8.9",
+		"verified": "9"
+	},
 	"esmodules": "{{sources}}",
 	"styles": "{{css}}",
 	"languages": [

--- a/df-light-regions/module.json
+++ b/df-light-regions/module.json
@@ -4,8 +4,10 @@
 	"version": "1.0.0",
 	"description": "Light Regions for Faster Vision",
 	"author": "flamewave000#0001",
-	"minimumCoreVersion": "9",
-	"compatibleCoreVersion": "9",
+	"compatibility": {
+		"minimum": "9",
+		"verified": "9"
+	},
 	"esmodules": "{{sources}}",
 	"styles": "{{css}}",
 	"languages": [

--- a/df-logger/module.json
+++ b/df-logger/module.json
@@ -4,8 +4,10 @@
 	"version": "1.6.8",
 	"description": "Prints a simple message whenever a user logs-in/out of FoundryVTT",
 	"author": "flamewave000#0001",
-	"minimumCoreVersion": "0.8.8",
-	"compatibleCoreVersion": "9",
+	"compatibility": {
+		"minimum": "0.8.8",
+		"verified": "9"
+	},
 	"esmodules": "{{sources}}",
 	"styles": "{{css}}",
 	"languages": [

--- a/df-manual-rolls/module.json
+++ b/df-manual-rolls/module.json
@@ -4,11 +4,15 @@
 	"version": "2.3.1",
 	"description": "Provides a way for a user to enter a custom value for rolls. This is to facilitate rolling real dice and then providing the values to Foundry to use.",
 	"author": "flamewave000#0001",
-	"minimumCoreVersion": "9",
-	"compatibleCoreVersion": "9",
+	"compatibility": {
+		"minimum": "9",
+		"verified": "9"
+	},
 	"esmodules": "{{sources}}",
 	"styles": "{{css}}",
-	"dependencies": [ { "name": "lib-wrapper" } ],
+	"relationships": {
+		"requires": [ { "name": "lib-wrapper" } ]
+	},
 	"languages": [
 		{ "lang": "en", "name": "English", "path": "lang/en.json" },
 		{ "lang": "pl", "name": "Polski", "path": "lang/pl.json" }

--- a/df-qol/module.json
+++ b/df-qol/module.json
@@ -4,9 +4,13 @@
 	"title": "DF Quality of Life",
 	"description": "A set of various small Quality of Life changes that don't quite fit in my other larger modules.",
 	"author": "flamewave000#0001",
-	"minimumCoreVersion": "9",
-	"compatibleCoreVersion": "9",
-	"dependencies": [ { "name": "lib-wrapper" } ],
+	"compatibility": {
+		"minimum": "9",
+		"verified": "9"
+	},
+	"relationships": {
+		"requires": [ { "id": "lib-wrapper" } ]
+	},
 	"esmodules": "{{sources}}",
 	"languages": [
 		{ "lang": "en", "name": "English", "path": "lang/en.json" },

--- a/df-scene-enhance/module.json
+++ b/df-scene-enhance/module.json
@@ -4,9 +4,13 @@
 	"title": "DF Scene Enhancement",
 	"description": "A few enhancements to scene management for players and GMs.",
 	"author": "flamewave000#0001",
-	"minimumCoreVersion": "9",
-	"compatibleCoreVersion": "9",
-	"dependencies": [ { "name": "lib-wrapper" } ],
+	"compatibility": {
+		"minimum": "9",
+		"verified": "9"
+	},
+	"relationships": {
+		"requires": [ { "id": "lib-wrapper" } ]
+	},
 	"esmodules": "{{sources}}",
 	"languages": [
 		{ "lang": "en", "path": "lang/en.json", "name": "English" },

--- a/df-settings-clarity/module.json
+++ b/df-settings-clarity/module.json
@@ -4,10 +4,14 @@
 	"title": "DF Settings Clarity",
 	"description": "Displays a tag next to each module setting, indicating if it is a World setting (GM Only) or a client setting (Per User).",
 	"author": "flamewave000#0001",
-	"minimumCoreVersion": "0.7.9",
-	"compatibleCoreVersion": "0.8.7",
+	"compatibility": {
+		"minimum": "0.7.9",
+		"verified": "0.8.7"
+	},
 	"scripts": [ "src/lib/fuzzysort.js" ],
-	"dependencies": [ { "name": "lib-wrapper" } ],
+	"relationships": {
+		"requires": [ { "id": "lib-wrapper" } ]
+	},
 	"esmodules": "{{sources}}",
 	"styles": "{{css}}",
 	"languages": [

--- a/df-templates/module.json
+++ b/df-templates/module.json
@@ -4,9 +4,13 @@
 	"title": "DF Template Enhancements",
 	"description": "Enhanced templates for different types of grid targetting.",
 	"author": "flamewave000#0001",
-	"minimumCoreVersion": "9",
-	"compatibleCoreVersion": "9",
-	"dependencies": [ { "name": "lib-wrapper" } ],
+	"compatibility": {
+		"minimum": "9",
+		"verified": "9"
+	},
+	"relationships": {
+		"requires": [ { "id": "lib-wrapper" } ]
+	},
 	"esmodules": "{{sources}}",
 	"styles": "{{css}}",
 	"languages": [

--- a/lib-df-buttons/module.json
+++ b/lib-df-buttons/module.json
@@ -4,8 +4,10 @@
 	"version": "1.3.2",
 	"description": "Library that provides a way for modules to register controls outside of the scene layer controls",
 	"author": "flamewave000#0001",
-	"minimumCoreVersion": "9.255",
-	"compatibleCoreVersion": "9",
+	"compatibility": {
+		"minimum": "9.255",
+		"verified": "9"
+	},
 	"esmodules": "{{sources}}",
 	"styles": "{{css}}",
 	"languages": [


### PR DESCRIPTION
Update module.js deprecated properties to use the recommended ones.
This will prevent a lot of console warnings when foundry verifies its modules.