### PR TITLE
Added support for exploding dice with manual rolls - likely fix issue #464

### DIFF
--- a/df-manual-rolls/lang/en.json
+++ b/df-manual-rolls/lang/en.json
@@ -9,7 +9,9 @@
 			"Flagged_Name": "Flag manual rolls",
 			"Flagged_Hint": "Add a flag to chat rolls that use manual dice.",
 			"FocusInput_Name": "Auto-Focus First Input Field",
-			"FocusInput_Hint": "If enabled, will set the focus to the first input field in the roll request window."
+			"FocusInput_Hint": "If enabled, will set the focus to the first input field in the roll request window.",
+			"ExplodingDice_Name": "Support Exploding Dice",
+			"ExplodingDice_Hint": "If enabled, allows entry of a roll that is higher the number of dice sides."
 		},
 		"Setting_Options": {
 			"Disabled": "Manual Rolls Disabled",

--- a/df-manual-rolls/lang/pl.json
+++ b/df-manual-rolls/lang/pl.json
@@ -11,7 +11,9 @@
 			"Flagged_Name": "Oznaczaj rzuty ręczne",
 			"Flagged_Hint": "Dodaje znacznik na czacie do rzutów wykonanych ręcznie.",
 			"FocusInput_Name": "Automatycznie wybieraj pierwsze pole tekstowe",
-			"FocusInput_Hint": "Po wyświetleniu dialogu z prośbą o rzuty kursor automatycznie przeniesiony zostanie na pierwsze pole tekstowe."
+			"FocusInput_Hint": "Po wyświetleniu dialogu z prośbą o rzuty kursor automatycznie przeniesiony zostanie na pierwsze pole tekstowe.",
+			"ExplodingDice_Name": "Wspieraj eksplodujące kości",
+			"ExplodingDice_Hint": "Jeśli ta opcja jest włączona, umożliwia wprowadzenie rzutu, który jest większy niż liczba ścianek kości."
 		},
 		"Setting_Options": {
 			"Disabled": "Wyłączone",

--- a/df-manual-rolls/src/ManualRolls.ts
+++ b/df-manual-rolls/src/ManualRolls.ts
@@ -13,6 +13,7 @@ export default class ManualRolls {
 	static PREF_PC_STATE = 'pc';
 	static PREF_FLAGGED = 'flagged';
 	static PREF_TOGGLED = 'toggled';
+	static PREF_EXPLODING_DICE = 'exploding';
 	static FLAG_ROLL_TYPE = 'roll-type';
 
 	static get flagged(): boolean { return SETTINGS.get(ManualRolls.PREF_FLAGGED); }

--- a/df-manual-rolls/src/RollPrompt.ts
+++ b/df-manual-rolls/src/RollPrompt.ts
@@ -11,7 +11,8 @@ interface RenderData {
 	idx: number;
 	faces: string;
 	hasTotal: boolean;
-	term: DiceTerm
+	term: DiceTerm;
+	supportExplodingDice: boolean;
 }
 
 export default class RollPrompt extends FormApplication<FormApplicationOptions, { terms: RenderData[] }> {
@@ -23,6 +24,7 @@ export default class RollPrompt extends FormApplication<FormApplicationOptions, 
 	private _rolled = false;
 
 	static get focusInput(): boolean { return SETTINGS.get(RollPrompt.PREF_FOCUS_INPUT); }
+	static get supportExplodingDice(): boolean { return SETTINGS.get(ManualRolls.PREF_EXPLODING_DICE); }
 
 	static get defaultOptions(): FormApplicationOptions {
 		return <FormApplicationOptions>mergeObject(
@@ -45,7 +47,8 @@ export default class RollPrompt extends FormApplication<FormApplicationOptions, 
 					idx: c,
 					faces: c == 0 ? `${die.number}d${die.faces}${die.modifiers.length > 0 ? ' [' + die.modifiers.join(',') + ']' : ''}` : '',
 					hasTotal: c == 0 && die.modifiers.length == 0 && die.number > 1,
-					term: die
+					term: die,
+					supportExplodingDice: RollPrompt.supportExplodingDice
 				});
 			}
 		}

--- a/df-manual-rolls/src/df-manual-rolls.ts
+++ b/df-manual-rolls/src/df-manual-rolls.ts
@@ -92,6 +92,15 @@ Hooks.on('init', function () {
 		}
 	});
 
+	SETTINGS.register(ManualRolls.PREF_EXPLODING_DICE, {
+		name: "DF_MANUAL_ROLLS.Settings.ExplodingDice_Name",
+		hint: "DF_MANUAL_ROLLS.Settings.ExplodingDice_Hint",
+		scope: 'world',
+		config: true,
+		type: Boolean,
+		default: false
+	});
+
 	RollSettings.init();
 });
 Hooks.on('ready', function () {

--- a/df-manual-rolls/templates/roll-prompt.hbs
+++ b/df-manual-rolls/templates/roll-prompt.hbs
@@ -15,11 +15,11 @@
 			{{#each terms}}
 			<tr>
 				<td>{{faces}}</td>
-				<td><input name="{{id}}-{{idx}}" type="number" min="1" max="{{term.faces}}" tabindex="1{{id}}{{idx}}"
+				<td><input name="{{id}}-{{idx}}" type="number" min="1" {{#unless supportExplodingDice}}max="{{term.faces}}"{{/unless}} tabindex="1{{id}}{{idx}}"
 						step="1" placeholder="1-{{term.faces}}{{localize "DF_MANUAL_ROLLS.Placeholder.Roll"}}"></input></td>
 				<td>
 					{{#if hasTotal}}
-					<input name="{{id}}-total" type="number" min="{{term.number}}" max="{{dfmr_mul term.number term.faces}}" tabindex="2{{id}}0"
+					<input name="{{id}}-total" type="number" min="{{term.number}}" {{#unless supportExplodingDice}}max="{{dfmr_mul term.number term.faces}}"{{/unless}} tabindex="2{{id}}0"
 						step="1" placeholder="{{localize "DF_MANUAL_ROLLS.Placeholder.Total_Pt1"}}{{term.number}}{{localize "DF_MANUAL_ROLLS.Placeholder.Total_Pt2"}}{{dfmr_mul term.number term.faces}}"></input>
 					{{/if}}
 				</td>


### PR DESCRIPTION
Added a setting to support Exploding Dice being manually entered (useful for systems such as Savage Worlds / SWADE). Likely resolves #464 

Previously, when the die value entered equals the maximum die value, the "exploding" dice are automatically generated afterwards behind the scenes and cannot be entered manually.  This setting removes the maximum value validation from the Roll Prompt form, allowing the total of all exploded dice to be entered as a single value, which works properly for further calculations.