### PR TITLE
DF Chat Enhancements: Merge chat message data flags instead of overwriting

### DIFF
--- a/df-chat-enhance/src/chat-time/chat-time.ts
+++ b/df-chat-enhance/src/chat-time/chat-time.ts
@@ -39,9 +39,14 @@ export default class ChatTime {
 
 		libWrapper.register(SETTINGS.MOD_NAME, 'ChatMessage.implementation.create',
 			(wrapped: (...args: any) => unknown, chatData: Partial<ChatMessageData>, createOptions: any) => {
-				chatData.flags = chatData.flags ?? {};
-				chatData.flags[SETTINGS.MOD_NAME] = {};
-				(chatData.flags[SETTINGS.MOD_NAME] as any)[this.FLAG_CHAT_TIME] = game.time.worldTime;
+				const timeFlags:any = {
+					flags: {
+						[SETTINGS.MOD_NAME]: {
+							[this.FLAG_CHAT_TIME]: game.time.worldTime
+						}
+					}
+				};
+				foundry.utils.mergeObject(chatData, timeFlags, {insertKeys: true, recursive: true});
 				return wrapped(chatData, createOptions);
 			}, 'WRAPPER');
 


### PR DESCRIPTION
When writing the WorldTime into the chat message data flags structure, DF Chat Enhancement would straight out overwrite the whole flags structure, wiping away all previously written flags. Since DF Chat Enhancement is often very late in the Hooks chain, this would mean most flags are destroyed.

This poses a problem when other modules would want to read from the flags, for example data written by the system. One such example is the Pathfinder 1e integration for https://github.com/otigon/automated-jb2a-animations . It would read the flags added by the system to determine when an attack (or spell cast) has taken place and use the attached source item name to match again a list of animations to play, as well as the attacker and attacke. So it can, for example, see that an attack with a crossbow has taken place and animate a crossbow bolt flying towards the target.

If, however, the system flags are wiped away by DF Chat Enhancements, Automated Animations fails to play any animations for any attacks, because it can't determine anything about the attack (or that, in fact, an attack has taken place). See https://github.com/otigon/automated-jb2a-animations/issues/669 .

This PR fixes the situation by using `foundry.utils.mergeObject()` to merge the DF Chat Enhancements flags into the existing chat message data object instead.

This also fixes #387, if I understand it correctly.