### PR TITLE
Address conflict with lancer system by using this.idx (#372)

### DIFF
--- a/df-manual-rolls/templates/roll-prompt.hbs
+++ b/df-manual-rolls/templates/roll-prompt.hbs
@@ -15,7 +15,7 @@
 			{{#each terms}}
 			<tr>
 				<td>{{faces}}</td>
-				<td><input name="{{id}}-{{idx}}" type="number" min="1" max="{{term.faces}}" tabindex="1{{id}}{{idx}}"
+				<td><input name="{{id}}-{{this.idx}}" type="number" min="1" max="{{term.faces}}" tabindex="1{{id}}{{this.idx}}"
 						step="1" placeholder="1-{{term.faces}}{{localize "DF_MANUAL_ROLLS.Placeholder.Roll"}}"></input></td>
 				<td>
 					{{#if hasTotal}}


### PR DESCRIPTION
This avoids a collision with Lancer's idx handlebar helper.

Reference: https://github.com/Eranziel/foundryvtt-lancer/blob/v1.6.1/src/lancer.ts#L292