### PR TITLE
DF Templates upgrade to Foundry v12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .devenv*
 .vscode/settings.json
 *foundry-reference*
+.idea/*

--- a/.template/module.json
+++ b/.template/module.json
@@ -3,7 +3,11 @@
 	"title": "Module Name",
 	"version": "1.0.0",
 	"description": "Description",
-	"author": "flamewave000#0001",
+	"author": [
+		{
+			"name": "flamewave000#0001"
+		}
+],
 	"minimumCoreVersion": "0.8.9",
 	"compatibleCoreVersion": "0.8.9",
 	"esmodules": "{{sources}}",
@@ -17,7 +21,6 @@
 	"download":	"https://dragonflagon.cafe/mods/pak/df-module-name",
 	"readme":	"https://github.com/flamewave000/dragonflagon-fvtt/tree/master/df-module-name/README.md",
 	"changelog":"https://github.com/flamewave000/dragonflagon-fvtt/tree/master/df-module-name/CHANGELOG.md",
-	"manifestPlusVersion": "1.0.0",
 	"bugs": "https://github.com/flamewave000/dragonflagon-fvtt/issues/new/choose",
 	"authors": [ { "name": "flamewave000", "discord": "flamewave000#0001", "url": "https://github.com/flamewave000" } ],
 	"media": [

--- a/df-templates/module.json
+++ b/df-templates/module.json
@@ -3,10 +3,10 @@
 	"version": "1.3.0",
 	"title": "DF Template Enhancements",
 	"description": "Enhanced templates for different types of grid targetting.",
-	"author": "flamewave000#0001",
 	"compatibility": {
-		"minimum": 10,
-		"verified": 10.288
+		"minimum": "12",
+		"verified": "12.331",
+		"maximum": "12.999"
 	},
 	"relationships": {
 		"requires": [
@@ -14,13 +14,13 @@
 				"id": "lib-wrapper",
 				"type": "module",
 				"compatibility": {
-					"verified": "1.12.10.0"
+					"verified": "1.13.2.0"
 				}
 			}
 		]
 	},
-	"esmodules": "{{sources}}",
-	"styles": "{{css}}",
+	"esmodules": ["src/main.js"],
+	"styles": ["css/df-templates.css"],
 	"languages": [
 		{ "lang": "en", "path": "lang/en.json", "name": "English" },
 		{ "lang": "ja", "path": "lang/ja.json", "name": "日本語" },
@@ -32,7 +32,6 @@
 	"download":	"https://dragonflagon.cafe/mods/pak/df-templates",
 	"readme":	"https://github.com/flamewave000/dragonflagon-fvtt/tree/master/df-templates/README.md",
 	"changelog":"https://github.com/flamewave000/dragonflagon-fvtt/tree/master/df-templates/CHANGELOG.md",
-	"manifestPlusVersion": "1.0.0",
 	"bugs": "https://github.com/flamewave000/dragonflagon-fvtt/issues",
 	"authors": [ { "name": "flamewave000", "discord": "flamewave000#0001", "url": "https://github.com/flamewave000" } ],
 	"media": [

--- a/df-templates/src/AngleSnaps.ts
+++ b/df-templates/src/AngleSnaps.ts
@@ -33,7 +33,7 @@ export default class AngleSnaps {
 	static ready() {
 		libWrapper.register(SETTINGS.MOD_NAME, 'canvas.templates._onMouseWheel', function (this: TemplateLayer, event: MouseEvent): any {
 			// Determine whether we have a hovered template?
-			const template = this.hover;
+			const template = this._hover;
 			if (!template) return;
 			// Determine the incremental angle of rotation from event data
 			const snapCount = SETTINGS.get<number>('angle-snap-macro');

--- a/df-templates/src/SquareTemplate.ts
+++ b/df-templates/src/SquareTemplate.ts
@@ -26,11 +26,19 @@ export default class SquareTemplate {
 		libWrapper.unregister(SETTINGS.MOD_NAME, 'MeasuredTemplate.prototype._refreshRulerText', false);
 	}
 
-	static MeasuredTemplate_getRectShape(this: MeasuredTemplate, distance: number, direction: number, adjustForRoundingError = false): PIXI.Polygon {
-		distance *= 10;
+	static MeasuredTemplate_getRectShape(this: MeasuredTemplate, distance: number, direction: number, adjustForRoundingError = false, directionInRadians = false, distanceAdjusted = false): PIXI.Polygon {
+		// This is a quick fix. In Foundry v12 the distance is provided a tenth, of what was provided in v10.
+		// Need to do more testing to find out why.
+		if(!distanceAdjusted)
+			distance *= 10;
+
+		// This is a quick fix. In Foundry v12 the direction is provided in radians, in v10 this was provided in degrees.
+		if(!directionInRadians)
+			direction = Math.toRadians(direction);
+
 		// Generate a rotation matrix to apply the rect against. The base rotation must be rotated
 		// CCW by 45° before applying the real direction rotation.
-		const matrix = PIXI.Matrix.IDENTITY.rotate((-45 * (Math.PI / 180)) + Math.toRadians(direction));
+		const matrix = PIXI.Matrix.IDENTITY.rotate((-45 * (Math.PI / 180)) + direction);
 		// If the shape will be used for collision, shrink the rectangle by a fixed EPSILON amount to account for rounding errors
 		const EPSILON = adjustForRoundingError ? 0.0001 : 0;
 		// Use simple Pythagoras to calculate the square's size from the diagonal "distance".

--- a/df-templates/src/SquareTemplate.ts
+++ b/df-templates/src/SquareTemplate.ts
@@ -18,18 +18,19 @@ export default class SquareTemplate {
 	}
 
 	private static patch() {
-		libWrapper.register(SETTINGS.MOD_NAME, 'MeasuredTemplate.prototype._getRectShape', SquareTemplate.MeasuredTemplate_getRectShape, 'OVERRIDE');
+		libWrapper.register(SETTINGS.MOD_NAME, 'MeasuredTemplate.getRectShape', SquareTemplate.MeasuredTemplate_getRectShape, 'OVERRIDE');
 		libWrapper.register(SETTINGS.MOD_NAME, 'MeasuredTemplate.prototype._refreshRulerText', SquareTemplate.MeasuredTemplate_refreshRulerText, 'WRAPPER');
 	}
 	private static unpatch() {
-		libWrapper.unregister(SETTINGS.MOD_NAME, 'MeasuredTemplate.prototype._getRectShape', false);
+		libWrapper.unregister(SETTINGS.MOD_NAME, 'MeasuredTemplate.getRectShape', false);
 		libWrapper.unregister(SETTINGS.MOD_NAME, 'MeasuredTemplate.prototype._refreshRulerText', false);
 	}
 
-	static MeasuredTemplate_getRectShape(this: MeasuredTemplate, direction: number, distance: number, adjustForRoundingError = false): PIXI.Polygon {
+	static MeasuredTemplate_getRectShape(this: MeasuredTemplate, distance: number, direction: number, adjustForRoundingError = false): PIXI.Polygon {
+		distance *= 10;
 		// Generate a rotation matrix to apply the rect against. The base rotation must be rotated
 		// CCW by 45° before applying the real direction rotation.
-		const matrix = PIXI.Matrix.IDENTITY.rotate((-45 * (Math.PI / 180)) + direction);
+		const matrix = PIXI.Matrix.IDENTITY.rotate((-45 * (Math.PI / 180)) + Math.toRadians(direction));
 		// If the shape will be used for collision, shrink the rectangle by a fixed EPSILON amount to account for rounding errors
 		const EPSILON = adjustForRoundingError ? 0.0001 : 0;
 		// Use simple Pythagoras to calculate the square's size from the diagonal "distance".

--- a/df-templates/src/TemplateTargeting.ts
+++ b/df-templates/src/TemplateTargeting.ts
@@ -45,6 +45,7 @@ export default class TemplateTargeting {
 	private static readonly TARGETING_MODE_PREF = "template-targeting";
 	private static readonly GRIDLESS_RESOLUTION_PREF = "template-gridless-resolution";
 	private static readonly GRIDLESS_PERCENTAGE_PREF = "template-gridless-percentage";
+	private static readonly INTERACTION_MODE_GRABBED = 4;
 
 	private static readonly PointGraphContainer = new PIXI.Graphics();
 
@@ -177,7 +178,7 @@ export default class TemplateTargeting {
 		const isOwner = this.document.author.id === game.userId;
 		// Release all previously targeted tokens
 		// @ts-ignore
-		if ((this.hover || !this.id) && isOwner && shouldAutoSelect && canvas.tokens.objects) {
+		if ((this.interactionState === TemplateTargeting.INTERACTION_MODE_GRABBED || !this.id) && isOwner && shouldAutoSelect && canvas.tokens.objects) {
 			for (const t of game.user.targets) {
 				t.setTarget(false, { releaseOthers: false, groupSelection: true });
 			}
@@ -210,10 +211,6 @@ export default class TemplateTargeting {
 			if (points[c + 1] < shapeBounds.top) shapeBounds.top = points[c + 1];
 			if (points[c + 1] > shapeBounds.bottom) shapeBounds.bottom = points[c + 1];
 		}
-		// @ts-ignore
-		// const snappedTopLeft = canvas.grid.getSnappedPosition(shapeBounds.left, shapeBounds.top, 1);
-		// @ts-ignore
-		// const snappedBottomRight = canvas.grid.getSnappedPosition(shapeBounds.right, shapeBounds.bottom, 1);
 
 		// @ts-ignore
 		const snappedTopLeft = canvas.grid.getSnappedPoint({x:shapeBounds.left, y:shapeBounds.top}, {mode: CONST.GRID_SNAPPING_MODES.CORNER , interval: 1});
@@ -482,7 +479,7 @@ export default class TemplateTargeting {
 
 				// Ignore changing the target selection if we don't own the template, or `shouldAutoSelect` is false
 				// @ts-ignore
-				if ((!this.hover && this.id) || !isOwner || !shouldAutoSelect) continue;
+				if ((this.interactionState !== TemplateTargeting.INTERACTION_MODE_GRABBED && this.id) || !isOwner || !shouldAutoSelect) continue;
 
 				// If we are using Point based targetting for this template
 				// @ts-ignore

--- a/df-templates/src/TemplateTargeting.ts
+++ b/df-templates/src/TemplateTargeting.ts
@@ -367,9 +367,8 @@ export default class TemplateTargeting {
 						break;
 					}
 					case "rect": {
-						//const rect = (this as any).getRectShape(direction, distance, true);
 						// @ts-ignore
-						const rect = MeasuredTemplate.getRectShape(direction, distance, true);
+						const rect = MeasuredTemplate.getRectShape(distance, direction, true, true, true);
 						if (rect instanceof PIXI.Polygon) {
 							contains = this.shape.contains(testX - this.document.x, testY - this.document.y);
 							if (contains || TemplateConfig.config.rect === HighlightMode.CENTER) break;


### PR DESCRIPTION
Made changes to the df-templates module to be compatible with Foundry v12.
As there is no release of @league-of-foundry-developers/foundry-vtt-types for v12 in the npm registry, I added @ts-ignore comments wherever new functions needed to be called.